### PR TITLE
Support pet packaging with cide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOFLAGS=
-GOREV:=-ldflags "-X main.build \"SHA: $(shell git rev-parse HEAD) (Built $(shell date) with $(shell go version))\""
+GOREV:=-ldflags "-X 'main.build=SHA: $(shell git rev-parse HEAD) (Built $(shell date) with $(shell go version))'"
 PREFIX=/usr/local
 
 all: fmt test crank crankctl

--- a/cide.yml
+++ b/cide.yml
@@ -1,0 +1,3 @@
+---
+from: golang:1.9
+run: script/ci

--- a/script/build
+++ b/script/build
@@ -1,0 +1,25 @@
+#! /bin/bash -e
+
+TARGET=$1
+
+if [[ -z $TARGET ]]; then
+    echo "No target set!"
+    exit 1
+fi
+
+GOSRC=/go/src/github.com/pusher/crank
+
+mkdir -p $GOSRC
+cp -R cmd man src crankx Makefile $GOSRC
+cd $GOSRC
+make install PREFIX=$TARGET
+
+mkdir -p $TARGET/.packager/bin
+mkdir -p $TARGET/.packager/man
+
+ln -s ../../bin/crank $TARGET/.packager/bin/crank
+ln -s ../../bin/crankctl $TARGET/.packager/bin/crankctl
+ln -s ../../bin/crankx $TARGET/.packager/bin/crankx
+ln -s ../../share/man/man1/crank.1 $TARGET/.packager/man/crank.1
+ln -s ../../share/man/man1/crankctl.1 $TARGET/.packager/man/crankctl.1
+ln -s ../../share/man/man1/crankx.1 $TARGET/.packager/man/crankx.1

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+cd "$(dirname "$0")/.."
+
+GOSRC=/go/src/github.com/pusher/crank
+
+mkdir -p $GOSRC
+cp -R cmd src Makefile $GOSRC
+cd $GOSRC
+make
+


### PR DESCRIPTION
This allows for building in docker with cide.

This PR also supports packaging the code: cide is configured to use `script/build` when building a package, which creates a deployable pet package.